### PR TITLE
brew: Command not found on M1/M2 macs

### DIFF
--- a/projects/project0.md
+++ b/projects/project0.md
@@ -164,6 +164,7 @@ Check the [Special macOS Instructions](#special-macos-instructions) to check if 
 
 1. Install the Homebrew package manager (Updated in Fall 2021)
     - Run `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+    - Try running `brew doctor`, if you see an error message saying "Command not found", run `eval $(/opt/homebrew/bin/brew shellenv)`
 2. Install python
     - Run `brew install python3`
     - Restart your terminal after the installation has completed and type `python3 --version`. Confirm it is 3.8 or higher

--- a/projects/project0.md
+++ b/projects/project0.md
@@ -164,7 +164,8 @@ Check the [Special macOS Instructions](#special-macos-instructions) to check if 
 
 1. Install the Homebrew package manager (Updated in Fall 2021)
     - Run `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
-    - Try running `brew doctor`, if you see an error message saying "Command not found", run `eval $(/opt/homebrew/bin/brew shellenv)`
+    - Try running `brew doctor`
+      - If you see an error message saying "Command not found", run `echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> $HOME/.zprofile` to add brew to PATH variable
 2. Install python
     - Run `brew install python3`
     - Restart your terminal after the installation has completed and type `python3 --version`. Confirm it is 3.8 or higher


### PR DESCRIPTION

> [!NOTE]
> - fixes an issue with `brew` on M1/M2 macs by adding brew to PATH

> [!IMPORTANT]
> ![image](https://github.com/cmsc330fall23/cmsc330fall23/assets/31113245/8d0556a4-cff7-4040-be09-d94bd5b5841e)
> # pls merge

> [!WARNING]
> ![image](https://github.com/cmsc330fall23/cmsc330fall23/assets/31113245/de6fe60c-48ec-4c73-a82e-b3d121a725b2)
