### PR TITLE
should be Staff not Person in example code for P1

### DIFF
--- a/projects/project1.md
+++ b/projects/project1.md
@@ -220,7 +220,7 @@ This will hold all the `Person`s. You should make your own `__init__` method..
   ```py
   roster = Roster()
   roster.size() == 0
-  roster.add(Person('Cliff', 84, 'Professor'))
+  roster.add(Staff('Cliff', 84, 'Professor'))
   roster.size() == 1
   ```
 


### PR DESCRIPTION
Person only accepts 2 arguments for init function
```py
roster.add(Person("Cliff", 84, "Professor"))
```
so Staff should've been used instead im assuming
```py
roster.add(Staff("Cliff", 84, "Professor"))
```